### PR TITLE
Fix step by step instructions link rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ It is a small Java project that has the [Develocity Maven Extension][manual] alr
 Follow these simple steps to create and publish a Build Scan® on [scans.gradle.com][scans.gradle.com]:
 
 1. Clone this project
-1. Run `./mvnw clean test`
+2. Run `./mvnw clean test`
+3. Agree to the [Terms of Service][terms-of-service] on the command line
 
 The build should end with something similar to:
 
@@ -42,5 +43,6 @@ The Maven Build Scan® quickstart project is open-source software released under
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html
 [manual]: https://docs.gradle.com/enterprise/maven-extension
 [gradle.com]: https://www.gradle.com
+[terms-of-service]: https://gradle.com/terms-of-service
 [scans.gradle.com]: https://scans.gradle.com
 [gradle-forum]: https://discuss.gradle.org/c/help-discuss/scans

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create different kinds of Build Scans by locally modifying this quickstart proje
 - Edit `src/main/java/example/Example.java` to introduce compile errors
 - Add more plugins and more projects
 
-Alternatively, enable one of your own Maven builds to produce Build Scans by following the [step-by-step instructions][https://scans.gradle.com/#maven].
+Alternatively, enable one of your own Maven builds to produce Build Scans by following the [step-by-step instructions](https://scans.gradle.com/#maven).
 
 ## Learn more
 
@@ -42,6 +42,5 @@ The Maven Build Scan® quickstart project is open-source software released under
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html
 [manual]: https://docs.gradle.com/enterprise/maven-extension
 [gradle.com]: https://www.gradle.com
-[terms-of-service]: https://gradle.com/terms-of-service
 [scans.gradle.com]: https://scans.gradle.com
 [gradle-forum]: https://discuss.gradle.org/c/help-discuss/scans


### PR DESCRIPTION
Step by step instructions link is not properly formatted.

<img width="909" alt="Screenshot 2024-02-21 at 12 29 04" src="https://github.com/gradle/maven-build-scan-quickstart/assets/1210272/2c458003-9819-4da8-aa15-f5fdb7430a9c">
